### PR TITLE
Make a convenient way to time functions' execution speeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Make a PR! Say roughly what you've changed, why you did so, and any ancillary da
 
 * Sign up for npmjs.com
 * merge PR into master
-* bump version
+* bump to <version>
 * update Changelog
-* `npm publish` !
-
+* `npm publish`
+* `git tag <version>`
 
 # Cool Contributors :sunglasses:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ I.increment('metric.name' /*, value = 1, time = now, count = 1 */);
 // gauges
 I.gauge('metric.name', 82.12 /*, time = now, count = 1 */);
 
+// time a function (seconds)
+I.time('metric.name', () => { do_something_expensive(arg1); } /*, multiplier = 1, time = now */)
+
 // notices
 I.notice('An event occurred' /*, duration = 0, time = now */);
 ````

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ I.gauge('metric.name', 82.12 /*, time = now, count = 1 */);
 I.time('metric.name', () => { do_something_expensive(arg1); } /*, multiplier = 1, time = now */);
 
 // time a function (milliseconds)
-I.time_ms('metric.name', () => { do_something_expensive(arg1); } /*, time = now);
+I.time_ms('metric.name', () => { do_something_expensive(arg1); } /*, time = now */);
 
 // notices
 I.notice('An event occurred' /*, duration = 0, time = now */);

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ I.increment('metric.name' /*, value = 1, time = now, count = 1 */);
 I.gauge('metric.name', 82.12 /*, time = now, count = 1 */);
 
 // notices
-I.notice('An event occurred' /*, time = now, duration = 0 */);
+I.notice('An event occurred' /*, duration = 0, time = now */);
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ I.increment('metric.name' /*, value = 1, time = now, count = 1 */);
 // gauges
 I.gauge('metric.name', 82.12 /*, time = now, count = 1 */);
 
-// time a function (seconds)
-I.time('metric.name', () => { do_something_expensive(arg1); } /*, multiplier = 1, time = now */)
+// time a function (seconds), multiplier can allow you to record on a different time period.
+I.time('metric.name', () => { do_something_expensive(arg1); } /*, multiplier = 1, time = now */);
+
+// time a function (milliseconds)
+I.time_ms('metric.name', () => { do_something_expensive(arg1); } /*, time = now);
 
 // notices
 I.notice('An event occurred' /*, duration = 0, time = now */);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
-var Instrumental = require('./lib/instrumental');
+const Instrumental = require('./lib/instrumental');
 module.exports = new Instrumental();

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -143,6 +143,17 @@ class Instrumental {
     this.apiCall('gauge', metric, value, time, count);
   }
 
+  time(metric, func, multiplier, time) {
+    const start = new Date();
+    if (multiplier === null || multiplier === undefined) { multiplier = 1; }
+    try {
+      return func();
+    } finally {
+      const duration = new Date() - start;
+      const timeToReport = duration / 1000 * multiplier;
+      this.apiCall('gauge', metric, timeToReport, time, 1);
+    }
+  }
   notice(description, duration, time) {
     this.apiCall('notice', description, duration, time);
   }

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -61,13 +61,23 @@ class Instrumental {
     });
   }
 
-  apiCall(type, metric, value, time, count) {
-    if (!this.enabled) { return; }
-    if (!time) { time = Date.now(); }
-    setImmediate(() => { this.apiCallInner(type, metric, value, time, count); });
+  record(metricParts) {
+    const line = metricParts.join(' ') + '\n';
+    if (this.connected) {
+      this.socket.write(line);
+    } else {
+      if (!this.socket) {
+        this.connect();
+      }
+      if (this.queuedCalls.length > 1000) {
+        debug('Queue too large - dropping notice event');
+        return;
+      }
+      this.queuedCalls.push(line);
+    }
   }
 
-  apiCallInner(type, metric, value, time, count) {
+  metricApiCallInner(type, metric, value, time, count) {
     if (!metric) {
       debug('Metric name required');
       return;
@@ -86,46 +96,41 @@ class Instrumental {
       return;
     }
 
-    if (!time) { time = Date.now(); }
-    time = Math.round(Number(time) / 1000);
-
-    const line = [type, metric, value, time, count].join(' ') + '\n';
-    if (this.connected) {
-      this.socket.write(line);
-    } else {
-      if (!this.socket) { this.connect(); }
-      if (this.queuedCalls.length > 1000) {
-        debug('Queue too large - dropping metric');
-        return;
-      }
-      this.queuedCalls.push(line);
-    }
+    this.record([type, metric, value, time, count]);
   }
 
-  noticeApiCallInner(type, desc, time, duration) {
-    if (!this.enabled) { return; }
-    if (!time) { time = Date.now(); }
-    time = Math.round(Number(time) / 1000);
+  gaugeApiCallInner() { this.metricApiCallInner.apply(this, arguments); }
+  incrementApiCallInner() { this.metricApiCallInner.apply(this, arguments); }
+
+  noticeApiCallInner(type, description, duration, time) {
+    if (!description) {
+      debug('Description required');
+      return;
+    }
+
     if (duration === null || duration === undefined) { duration = 0; }
     duration = Number(duration);
+    if (duration < 0) {
+      debug('duration cannot be negative');
+      return;
+    }
     if (!isFinite(duration)) {
       debug('duration is invalid');
       return;
     }
 
-    const line = [type, time, duration, desc].join(' ') + '\n';
-    if (this.connected) {
-      this.socket.write(line);
-    } else {
-      if (!this.socket) {
-        this.connect();
-      }
-      if (this.queuedCalls.length > 1000) {
-        debug('Queue too large - dropping notice event');
-        return;
-      }
-      this.queuedCalls.push(line);
-    }
+    this.record([type, time, duration, description]);
+  }
+
+  unixTimeSeconds(time) {
+    if (!time) { time = Date.now(); }
+    return Math.round(Number(time) / 1000);
+  }
+
+  apiCall(type, descriptor, value, time, count) {
+    if (!this.enabled) { return; }
+    time = this.unixTimeSeconds(time);
+    setImmediate(() => { this[`${type}ApiCallInner`](type, descriptor, value, time, count); });
   }
 
   increment(metric, value, time, count) {
@@ -138,10 +143,8 @@ class Instrumental {
     this.apiCall('gauge', metric, value, time, count);
   }
 
-  notice(description, time, duration) {
-    setImmediate(() => {
-      this.noticeApiCallInner('notice', description, time, duration);
-    });
+  notice(description, duration, time) {
+    this.apiCall('notice', description, duration, time);
   }
 
 }

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var net   = require('net');
-var debug = require('debug')('instrumental');
-
 const VERSION = require('../package.json').version;
+const net     = require('net');
+const debug   = require('debug')('instrumental');
 
 class Instrumental {
 
@@ -12,14 +11,14 @@ class Instrumental {
     this.enabled = false;
   }
 
-  configure(options){
+  configure(options) {
     this.apiKey  = options.apiKey;
     this.enabled = options.enabled === undefined ? true : options.enabled;
     this.host    = options.host || 'collector.instrumentalapp.com';
   }
 
-  connect(){
-    if(this.socket){ return; }
+  connect() {
+    if (this.socket) { return; }
 
     debug('Opening Instrumental connection');
     this.socket = net.createConnection({ host: this.host, port: 8000 });
@@ -41,7 +40,7 @@ class Instrumental {
       this.socket.removeAllListeners();
       this.connected = false;
       this.socket = null;
-      if(this.queuedCalls.length > 0){
+      if (this.queuedCalls.length > 0) {
         setTimeout(() => { this.connect(); }, 5000);
       }
     });
@@ -62,40 +61,40 @@ class Instrumental {
     });
   }
 
-  apiCall(type, metric, value, time, count){
-    if(!this.enabled){ return; }
-    if(!time){ time = Date.now(); }
+  apiCall(type, metric, value, time, count) {
+    if (!this.enabled) { return; }
+    if (!time) { time = Date.now(); }
     setImmediate(() => { this.apiCallInner(type, metric, value, time, count); });
   }
 
-  apiCallInner(type, metric, value, time, count){
-    if(!metric){
+  apiCallInner(type, metric, value, time, count) {
+    if (!metric) {
       debug('Metric name required');
       return;
     }
 
     value = Number(value);
-    if(!isFinite(value)){
+    if (!isFinite(value)) {
       debug('Metric value is invalid');
       return;
     }
 
-    if(count === null || count === undefined){ count = 1; }
+    if (count === null || count === undefined) { count = 1; }
     count = Number(count);
-    if(!isFinite(count)){
+    if (!isFinite(count)) {
       debug('Metric count is invalid');
       return;
     }
 
-    if(!time){ time = Date.now(); }
+    if (!time) { time = Date.now(); }
     time = Math.round(Number(time) / 1000);
 
-    var line = [type, metric, value, time, count].join(' ') + '\n';
-    if(this.connected){
+    const line = [type, metric, value, time, count].join(' ') + '\n';
+    if (this.connected) {
       this.socket.write(line);
     } else {
-      if(!this.socket){ this.connect(); }
-      if(this.queuedCalls.length > 1000){
+      if (!this.socket) { this.connect(); }
+      if (this.queuedCalls.length > 1000) {
         debug('Queue too large - dropping metric');
         return;
       }
@@ -104,23 +103,20 @@ class Instrumental {
   }
 
   noticeApiCallInner(type, desc, time, duration) {
-    if(!this.enabled){ return; }
-    if (!time) {
-      time = Date.now();
-    }
+    if (!this.enabled) { return; }
+    if (!time) { time = Date.now(); }
     time = Math.round(Number(time) / 1000);
-    if(duration === null || duration === undefined){ duration = 0; }
+    if (duration === null || duration === undefined) { duration = 0; }
     duration = Number(duration);
-    if(!isFinite(duration)){
+    if (!isFinite(duration)) {
       debug('duration is invalid');
       return;
     }
 
-    var line = [type, time, duration, desc].join(' ') + '\n';
+    const line = [type, time, duration, desc].join(' ') + '\n';
     if (this.connected) {
       this.socket.write(line);
-    }
-    else {
+    } else {
       if (!this.socket) {
         this.connect();
       }
@@ -132,13 +128,13 @@ class Instrumental {
     }
   }
 
-  increment(metric, value, time, count){
-    if(value === 0){ return; }
-    if(value === null || value === undefined){ value = 1; }
+  increment(metric, value, time, count) {
+    if (value === 0) { return; }
+    if (value === null || value === undefined) { value = 1; }
     this.apiCall('increment', metric, value, time, count);
   }
 
-  gauge(metric, value, time, count){
+  gauge(metric, value, time, count) {
     this.apiCall('gauge', metric, value, time, count);
   }
 

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -154,6 +154,11 @@ class Instrumental {
       this.apiCall('gauge', metric, timeToReport, time, 1);
     }
   }
+
+  time_ms(metric, func, time) {
+    time(metric, func, 1000, time);
+  }
+
   notice(description, duration, time) {
     this.apiCall('notice', description, duration, time);
   }

--- a/test/intrumental-test.js
+++ b/test/intrumental-test.js
@@ -94,7 +94,7 @@ describe('Instrumental', () => {
       });
     });
 
-    I.notice('test is good', new Date(1455477257165), 0);
+    I.notice('test is good', 0, new Date(1455477257165));
   });
 
 });

--- a/test/intrumental-test.js
+++ b/test/intrumental-test.js
@@ -100,7 +100,7 @@ describe('Instrumental', () => {
     const testFunction = () => {
       function sleepFor(sleepDuration) {
         const now = new Date().getTime();
-        while (new Date().getTime() < now + sleepDuration) { /* do nothing */ }
+        while (new Date().getTime() < now + sleepDuration) { /* do nothing */ 0; }
       }
       sleepFor(10);
       return 42;

--- a/test/intrumental-test.js
+++ b/test/intrumental-test.js
@@ -1,35 +1,35 @@
 'use strict';
 
-var Instrumental = require('../lib/instrumental');
-var mitm = require('mitm');
+const Instrumental = require('../lib/instrumental');
+const mitm = require('mitm');
+
 require('should');
 const VERSION = require('../package.json').version;
 
-describe('Instrumental', function() {
-  beforeEach(function() { this.mitm = mitm(); });
-  afterEach(function() { this.mitm.disable(); });
+describe('Instrumental', () => {
+  beforeEach(function () { this.mitm = mitm(); });
+  afterEach(function () { this.mitm.disable(); });
 
-  it('should send gauge calls correctly', function(done) {
-    var expectedData = [
-      ['hello version node/instrumental_agent/'+VERSION+'\nauthenticate test\n', 'ok\nok\n'],
+  it('should send gauge calls correctly', function (done) {
+    const expectedData = [
+      [`hello version node/instrumental_agent/${VERSION}\nauthenticate test\n`, 'ok\nok\n'],
       ['gauge test.metric 5 1455477257 1\n']];
-    var index = 0;
+    const I = new Instrumental();
+    I.configure({ apiKey: 'test', enabled: true });
 
-    var I = new Instrumental();
-    I.configure({apiKey: 'test', enabled: true});
+    let index = 0;
 
     this.mitm.on('connection', (socket) => {
       socket.on('data', (data) => {
         data.toString().should.equal(expectedData[index][0]);
-        if(expectedData[index][1])
-        { socket.write(expectedData[index][1]); }
+        if (expectedData[index][1]) { socket.write(expectedData[index][1]); }
 
         index++;
-        if(index === 2) {
+        if (index === 2) {
           expectedData.push(['gauge test.metric2 0 ' +
-            Math.round(Date.now()/1000) + ' 1\n']);
+                             Math.round(Date.now() / 1000) + ' 1\n']);
           I.gauge('test.metric2', 0);
-        } else if(index === 3) {
+        } else if (index === 3) {
           done();
         }
       });
@@ -38,42 +38,37 @@ describe('Instrumental', function() {
     I.gauge('test.metric', 5, new Date(1455477257165));
   });
 
-  it('should send increment calls correctly', function(done) {
-    var expectedData = [
-      ['hello version node/instrumental_agent/'+VERSION+'\nauthenticate test\n', 'ok\nok\n'],
+  it('should send increment calls correctly', function (done) {
+    const expectedData = [
+      [`hello version node/instrumental_agent/${VERSION}\nauthenticate test\n`, 'ok\nok\n'],
       ['increment test.metric 5 1455477257 1\n']];
-    var index = 0;
+    const I = new Instrumental();
+    I.configure({ apiKey: 'test', enabled: true });
 
-    var I = new Instrumental();
-    I.configure({apiKey: 'test', enabled: true});
+    let index = 0;
 
     this.mitm.on('connection', (socket) => {
       socket.on('data', (data) => {
         data.toString().should.equal(expectedData[index][0]);
-        if(expectedData[index][1])
-        { socket.write(expectedData[index][1]); }
+        if (expectedData[index][1]) { socket.write(expectedData[index][1]); }
 
         index++;
-        if(index === 2) {
+        if (index === 2) {
           expectedData.push(['increment test.metric2 1 ' +
-            Math.round(Date.now()/1000) + ' 1\n']);
+                             Math.round(Date.now() / 1000) + ' 1\n']);
           I.increment('test.metric2');
-    }
-    else if(index === 3){
-      expectedData.push(['increment test.metric3 1 ' +
-      Math.round(Date.now()/1000) + ' 1\n']);
-      //this should trigger addition to the socket queue.
-      I.increment('test.metric3');
-      I.increment('test.metric4');
-
-    }
-    else if(index === 4) {
-      expectedData.push(['increment test.metric4 1 ' +
-      Math.round(Date.now()/1000) + ' 1\n']);
+        } else if (index === 3) {
+          expectedData.push(['increment test.metric3 1 ' +
+                             Math.round(Date.now() / 1000) + ' 1\n']);
+          //this should trigger addition to the socket queue.
+          I.increment('test.metric3');
+          I.increment('test.metric4');
+        } else if (index === 4) {
+          expectedData.push(['increment test.metric4 1 ' +
+                             Math.round(Date.now() / 1000) + ' 1\n']);
+        } else if (index === 5) {
+          done();
         }
-    else if(index === 5){
-      done();
-    }
       });
     });
 
@@ -81,25 +76,21 @@ describe('Instrumental', function() {
     I.increment('discard.cause.zero', 0);
   });
 
-  it('should send notice calls correctly', function(done) {
-    var expectedData = [
-      ['hello version node/instrumental_agent/'+VERSION+'\nauthenticate test\n', 'ok\nok\n'],
+  it('should send notice calls correctly', function (done) {
+    const expectedData = [
+      [`hello version node/instrumental_agent/${VERSION}\nauthenticate test\n`, 'ok\nok\n'],
       ['notice 1455477257 0 test is good\n']];
-    var index = 0;
+    const I = new Instrumental();
+    I.configure({ apiKey: 'test', enabled: true });
 
-    var I = new Instrumental();
-    I.configure({apiKey: 'test', enabled: true});
+    let index = 0;
 
     this.mitm.on('connection', (socket) => {
       socket.on('data', (data) => {
         data.toString().should.equal(expectedData[index][0]);
-        if(expectedData[index][1])
-        { socket.write(expectedData[index][1]); }
-
+        if (expectedData[index][1]) { socket.write(expectedData[index][1]); }
         index++;
-          if(index === 2) {
-            done();
-        }
+        if (index === 2) { done(); }
       });
     });
 


### PR DESCRIPTION
## What / Why

Funcs are `time` and `time_ms`, to match with the ruby agent's options.

To be used like:
```javascript
I.time("some.metric", () => { do_something_here });
```

-----

Builds on #6 and #8 